### PR TITLE
Normalize function signatures taking Function then

### DIFF
--- a/modules/casper.rst
+++ b/modules/casper.rst
@@ -1160,7 +1160,7 @@ Reloads current page location::
 ``repeat()``
 -------------------------------------------------------------------------------
 
-**Signature:** ``repeat(int times, function then)``
+**Signature:** ``repeat(int times, Function then)``
 
 Repeats a navigation step a given number of times::
 
@@ -1285,7 +1285,7 @@ Of course you can directly pass the auth string in the url to open::
 ``start()``
 -------------------------------------------------------------------------------
 
-**Signature:** ``start(String url[, function then])``
+**Signature:** ``start(String url[, Function then])``
 
 Configures and starts Casper, then open the provided ``url`` and optionally adds the step provided by the ``then`` argument::
 
@@ -1351,7 +1351,7 @@ Returns the status of current Casper instance::
 ``then()``
 -------------------------------------------------------------------------------
 
-**Signature:** ``then(Function fn)``
+**Signature:** ``then(Function then)``
 
 This method is the standard way to add a new navigation step to the stack, by providing a simple function::
 
@@ -1434,9 +1434,9 @@ To run all the steps you defined, call the `run()`_ method, and voila.
 ``thenClick()``
 -------------------------------------------------------------------------------
 
-**Signature:** ``thenClick(String selector)``
+**Signature:** ``thenClick(String selector[, Function then])``
 
-Adds a new navigation step to click a given selector and add a new navigation step in a single operation::
+Adds a new navigation step to click a given selector and optionally add a new navigation step in a single operation::
 
     // Querying for "Chuck Norris" on Google
     casper.start('http://casperjs.org/').thenClick('a', function() {
@@ -1502,7 +1502,7 @@ You can also specify request settings by passing a setting object (see `open()`_
 ``thenOpenAndEvaluate()``
 -------------------------------------------------------------------------------
 
-**Signature:** ``thenOpenAndEvaluate(String location[, function then, Object replacements])``
+**Signature:** ``thenOpenAndEvaluate(String location[, Function then, Object replacements])``
 
 Basically a shortcut for opening an url and evaluate code against remote DOM environment::
 
@@ -1837,7 +1837,7 @@ The page context switch only lasts until the step execution is finished::
 ``withPopup()``
 -------------------------------------------------------------------------------
 
-**Signature:** ``withPopup(Mixed popupInfo, Function step)``
+**Signature:** ``withPopup(Mixed popupInfo, Function then)``
 
 .. versionadded:: 1.0
 


### PR DESCRIPTION
I noticed the documentation lacked `Function then` in some signatures, and that the function case wasn't always the same so I just fixed it.
